### PR TITLE
Add 'Troubleshooting' for issue with ctns-find/*

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,31 @@ The Graphviz dot file format is a text format, so this is useful when developing
 and debugging.
 
 
+## Troubleshooting
+
+#### `No such var: ctns-find/cljs`
+
+    Syntax error compiling at (leiningen/nomis_ns_graph/p200_graphing/graph.clj:68:27).
+            ...
+    Caused by: java.lang.RuntimeException: No such var: ctns-find/cljs
+
+`nomis-ns-graph` uses features of `org.clojure/tools.namespace` add in v3.0.0.
+If there are other plugins including tools.namespace prior 3.0.0, the required
+symbols are not available causing issues in this plugin.
+
+There are two workarounds for it:
+
+  1. change the order of plugins
+
+         :plugins [[lein-nomis-ns-graph "0.14.2"]
+                   [lein-kibit "0.1.6"]]
+
+  2. exclude tools.namespace from conflicting plugin
+
+         :plugins [[lein-kibit "0.1.6" :exclusions [org.clojure/tools.namespace]]
+                   [lein-nomis-ns-graph "0.14.2"]]
+
+
 ## Acknowledgments
 
 Inspired by the following:


### PR DESCRIPTION
Hi Simon,

I have included your plugin to my project and I had found an issue.

This PR is only extending README file. Feel free to decline it if you don't want to add this info to README. I just wanted to let you know somehow, and I thought if I need to describe the issue anyway, I can do in a PR extending a bit the project documentation :)


-----------

Error:
```
Syntax error compiling at (leiningen/nomis_ns_graph/p200_graphing graph.clj:68:27).
    ...
Caused by: java.lang.RuntimeException: No such var: ctns-find/cljs
```

If other plugin includes tools.namespaces vers < 3.0.0 and it is loaded
before this plugin, there will be a problem with accessing symbols
introduced in version 3.0.0 needed to a successful execution of this plugin.